### PR TITLE
Fix typo in TaskList comment

### DIFF
--- a/labs/architecture-examples/extjs/js/view/TaskList.js
+++ b/labs/architecture-examples/extjs/js/view/TaskList.js
@@ -30,7 +30,7 @@ Ext.define('Todo.view.TaskList' , {
 				}
 			}, this, {
 				// TODO I can't get this to delegate using something like div.view input or input[type="checkbox"]
-				// So this will have a bug with teh input.edit field... I need to figure that out so I don't have to
+				// So this will have a bug with the input.edit field... I need to figure that out so I don't have to
 				// do the if logic above.
 				delegate: 'input'
 			});


### PR DESCRIPTION
## Summary
- correct a typo in the ExtJS architecture example

## Testing
- `grep -n "the input.edit" -R labs/architecture-examples/extjs/js/view`


------
https://chatgpt.com/codex/tasks/task_e_683f7eb91c94832a8215c028a4dcb40c